### PR TITLE
Added superadmin check to isLeader

### DIFF
--- a/src/js/states/profile/profile.module.js
+++ b/src/js/states/profile/profile.module.js
@@ -36,7 +36,7 @@
 							return deferred.promise;
 						},
 						'isLeader': function ( $log, user, ministry ) {
-							return _.contains( user.admin, ministry.ministry_id );
+							return user.superadmin || _.contains( user.admin, ministry.ministry_id );
 						}
 					},
 					views:    {

--- a/src/js/states/select-ministry/select-ministry.controller.js
+++ b/src/js/states/select-ministry/select-ministry.controller.js
@@ -6,7 +6,7 @@
 		$scope.ministries = systems;
 
 		$scope.isLeader = function ( ministry_id ) {
-			return _.contains( user.admin, ministry_id );
+			return user.superadmin || _.contains( user.admin, ministry_id );
 		};
 	} );
 


### PR DESCRIPTION
Modify `isLeader` checks to accept new `superadmin` bit which will be sent with user data once https://github.com/CruGlobal/global-profile-api/pull/11 is merged.